### PR TITLE
Added triggers that send entries as messages automatically

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,8 @@
 
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.SEND_SMS" />
 
     <application

--- a/app/src/main/java/edu/uw/ischool/opensecrets/EntryOverviewEditActivity.kt
+++ b/app/src/main/java/edu/uw/ischool/opensecrets/EntryOverviewEditActivity.kt
@@ -16,6 +16,7 @@ import java.util.Calendar
 class EntryOverviewEditActivity : AppCompatActivity() {
 
     private lateinit var binding: EntryOverviewBinding
+    private lateinit var secretApp : SecretApp
 
     companion object {
         const val ENTRY = "entry"
@@ -27,6 +28,7 @@ class EntryOverviewEditActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        secretApp = (this.application as SecretApp)
         binding = EntryOverviewBinding.inflate(layoutInflater)
         setContentView(binding.root)
         val colors = resources.getStringArray(R.array.color_array)
@@ -117,7 +119,9 @@ class EntryOverviewEditActivity : AppCompatActivity() {
                     Toast.makeText(this, "Title should not be empty", Toast.LENGTH_SHORT).show()
                 } else {
                     val pos = intent?.extras?.getString(POSITION).toString().toInt()
-                    val status = (this.application as SecretApp).journalManager.updateEntry(
+                    secretApp.queueEntryFromPos(pos)
+
+                    val status = secretApp.journalManager.updateEntry(
                         pos,
                         Entry(
                             binding.entryTitle.text.toString(),
@@ -147,13 +151,15 @@ class EntryOverviewEditActivity : AppCompatActivity() {
                 if (binding.entryTitle.text.isEmpty()) {
                     Toast.makeText(this, "Title should not be empty", Toast.LENGTH_SHORT).show()
                 } else {
-                    val status = (this.application as SecretApp).journalManager.appendEntry(
-                        Entry(
-                            binding.entryTitle.text.toString(),
-                            binding.colorSpinner.selectedItem as String,
-                            intent?.extras?.getString(ENTRY).toString(),
-                            Calendar.getInstance().time
-                        )
+                    val entry : Entry = Entry(
+                        binding.entryTitle.text.toString(),
+                        binding.colorSpinner.selectedItem as String,
+                        intent?.extras?.getString(ENTRY).toString(),
+                        Calendar.getInstance().time
+                    )
+                    secretApp.queueSendEntry(entry)
+                    val status = secretApp.journalManager.appendEntry(
+                        entry
                     )
 
                     if (status) {

--- a/app/src/main/java/edu/uw/ischool/opensecrets/HomeActivity.kt
+++ b/app/src/main/java/edu/uw/ischool/opensecrets/HomeActivity.kt
@@ -10,6 +10,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import edu.uw.ischool.opensecrets.adapter.EntryAdapter
 import edu.uw.ischool.opensecrets.databinding.ActivityHomeBinding
+import edu.uw.ischool.opensecrets.model.Entry
 
 
 class HomeActivity : AppCompatActivity() {
@@ -96,7 +97,8 @@ class HomeActivity : AppCompatActivity() {
      */
     private fun deleteEntry(pos: Int) {
         val dialog =
-            DeleteEntryDialogFragment((this.application as SecretApp).journalManager::deleteEntry)
+            DeleteEntryDialogFragment((this.application as SecretApp).journalManager::deleteEntry,
+                (this.application as SecretApp)::queueEntryFromPos)
         val args = Bundle()
         args.putInt("pos", pos)
         dialog.arguments = args
@@ -111,7 +113,7 @@ class HomeActivity : AppCompatActivity() {
      * @param deleteFn The callback function to be call if user select "Yes" when prompted
      */
     class DeleteEntryDialogFragment(
-        val deleteFn: (Int) -> Boolean
+        val deleteFn: (Int) -> Boolean, val sendEntry: (Int) -> Unit
     ) : DialogFragment() {
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
             return activity?.let {
@@ -121,6 +123,7 @@ class HomeActivity : AppCompatActivity() {
                     .setPositiveButton("Yes") { _, _ ->
                         val pos = arguments?.getInt("pos")
                         if (pos != null) {
+                            sendEntry(pos)
                             if (deleteFn(pos)) {
                                 it.supportFragmentManager.setFragmentResult(
                                     "delete_event", bundleOf("delete_event" to "true")

--- a/app/src/main/java/edu/uw/ischool/opensecrets/MainActivity.kt
+++ b/app/src/main/java/edu/uw/ischool/opensecrets/MainActivity.kt
@@ -1,6 +1,7 @@
 package edu.uw.ischool.opensecrets
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import edu.uw.ischool.opensecrets.auth.LoginActivity
@@ -21,14 +22,29 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun requestPermission() {
-        requestPermissions(
-            arrayOf(
+        var permissions : Array<String>
+        if(Build.VERSION.SDK_INT >= 31){
+            permissions = arrayOf(
                 android.Manifest.permission.READ_CONTACTS,
                 android.Manifest.permission.INTERNET,
                 android.Manifest.permission.ACCESS_NETWORK_STATE,
                 android.Manifest.permission.SEND_SMS,
                 android.Manifest.permission.READ_PHONE_STATE,
-            ), 0
+                android.Manifest.permission.SCHEDULE_EXACT_ALARM,
+                android.Manifest.permission.USE_EXACT_ALARM
+            )
+        }
+        else {
+            permissions = arrayOf(
+                android.Manifest.permission.READ_CONTACTS,
+                android.Manifest.permission.INTERNET,
+                android.Manifest.permission.ACCESS_NETWORK_STATE,
+                android.Manifest.permission.SEND_SMS,
+                android.Manifest.permission.READ_PHONE_STATE
+            )
+        }
+        requestPermissions(
+            permissions, 0
         )
     }
 }

--- a/app/src/main/java/edu/uw/ischool/opensecrets/SecretApp.kt
+++ b/app/src/main/java/edu/uw/ischool/opensecrets/SecretApp.kt
@@ -33,6 +33,7 @@ class SecretApp : Application() {
     lateinit var optionManager: OptionManager
     override fun onCreate() {
         super.onCreate()
+        Log.i("SecretApp", "Build version: ${Build.VERSION.SDK_INT}")
     }
 
     fun loadRepository() {
@@ -66,7 +67,7 @@ class SecretApp : Application() {
             .setSmallIcon(R.drawable.round_home_24)
             .setContentTitle(title)
             .setContentText(textContent)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
 
         with(NotificationManagerCompat.from(context)) {
             if (ActivityCompat.checkSelfPermission(
@@ -80,7 +81,9 @@ class SecretApp : Application() {
         }
     }
     fun queueSendEntry(entry : Entry){
-        messageQueue.queueSendEntry(entry, 1.toLong())
+        val time : Long = optionManager.getMinTime().toLong()
+        Log.i("SecretApp", "Time to send message: $time")
+        messageQueue.queueSendEntry(entry, time)
     }
     fun queueEntryFromPos(pos : Int){
         val oldEntry : Entry? = journalManager.getEntryAt(pos)
@@ -94,7 +97,7 @@ class SecretApp : Application() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val name = "opensecretname"
             val descriptionText = "notif channel for our journaling app"
-            val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val importance = NotificationManager.IMPORTANCE_HIGH
             val channel = NotificationChannel(CHANNEL_ID, name, importance).apply {
                 description = descriptionText
             }

--- a/app/src/main/java/edu/uw/ischool/opensecrets/SecretApp.kt
+++ b/app/src/main/java/edu/uw/ischool/opensecrets/SecretApp.kt
@@ -82,6 +82,12 @@ class SecretApp : Application() {
     fun queueSendEntry(entry : Entry){
         messageQueue.queueSendEntry(entry, 1.toLong())
     }
+    fun queueEntryFromPos(pos : Int){
+        val oldEntry : Entry? = journalManager.getEntryAt(pos)
+        if(oldEntry != null){
+            queueSendEntry(oldEntry)
+        }
+    }
     private fun createNotificationChannel() {
         // Create the NotificationChannel, but only on API 26+ because
         // the NotificationChannel class is not in the Support Library.

--- a/app/src/main/java/edu/uw/ischool/opensecrets/model/TimedMessageQueue.kt
+++ b/app/src/main/java/edu/uw/ischool/opensecrets/model/TimedMessageQueue.kt
@@ -4,39 +4,36 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
-import android.content.Context.ALARM_SERVICE
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
-import android.os.SystemClock
 import android.util.Log
-import java.lang.System.currentTimeMillis
-import java.time.Instant
 
 const val ALARM_ACTION = "OpenSecretMessageAlarm"
 class TimedMessageQueue(val context : Context, val alarmManager: AlarmManager, val sendEntryLambda : (Entry) -> Unit) {
-    val queuedEntries : ArrayList<Entry> = ArrayList<Entry>()
+    val queuedEntries : MutableMap<Int, Entry> = mutableMapOf<Int, Entry>()
 //    val queuedPendings : ArrayList<PendingIntent> = ArrayList<PendingIntent>()
     var receiver : BroadcastReceiver? = null
     var requestCode : Int = 0
 
     fun queueSendEntry(entry : Entry, minutesToSend : Long){
-        requestCode += 1
+        requestCode = System.currentTimeMillis().toInt()
         if(receiver == null){
             receiver = object : BroadcastReceiver() {
                 override fun onReceive(context: Context?, intent: Intent?) {
-                    sendNextEntryInQueue()
+                    Log.i("Time", "Request code ${intent?.extras?.getInt("requestCode")}")
+                    sendNextEntryInQueue(intent?.extras?.getInt("requestCode"))
                 }
             }
 
             val filter = IntentFilter(ALARM_ACTION)
             context.registerReceiver(receiver, filter)
         }
-        val intent = Intent(ALARM_ACTION)
+        val intent = Intent(ALARM_ACTION).putExtra("requestCode", requestCode)
 
         val pendingIntent = PendingIntent.getBroadcast(context, requestCode, intent, PendingIntent.FLAG_IMMUTABLE)
 //        queuedPendings.add(pendingIntent)
-        queuedEntries.add(entry)
+        queuedEntries[requestCode] = entry
         if(Build.VERSION.SDK_INT < 31 || alarmManager.canScheduleExactAlarms()){
             Log.i("TimedMessageQueue", "sending entry ${entry.title} in $minutesToSend minutes")
             alarmManager.setExact(AlarmManager.RTC_WAKEUP,
@@ -47,17 +44,19 @@ class TimedMessageQueue(val context : Context, val alarmManager: AlarmManager, v
             Log.i("TimedMessageQueue", "Message Queue failed you, sorry")
         }
     }
-    fun sendNextEntryInQueue(){
+    fun sendNextEntryInQueue(requestCode: Int?) {
 //        if(queuedPendings.size > 0){
 //            queuedPendings.removeFirstOrNull()
 //        }
-        if(queuedEntries.size > 0){
-            val entryToSend : Entry = queuedEntries.removeFirst()
-            sendEntryLambda(entryToSend)
+        if(queuedEntries.isNotEmpty()){
+            val entryToSend : Entry? = queuedEntries.remove(requestCode)
+            if (entryToSend != null) {
+                sendEntryLambda(entryToSend)
+            }
         }
     }
     fun sendAllEntries(){
-        for(entry : Entry in queuedEntries){
+        for((key, entry : Entry) in queuedEntries){
             sendEntryLambda(entry)
         }
 //        for(pendingIntent : PendingIntent in queuedPendings){

--- a/app/src/main/java/edu/uw/ischool/opensecrets/util/JournalManager.kt
+++ b/app/src/main/java/edu/uw/ischool/opensecrets/util/JournalManager.kt
@@ -194,4 +194,28 @@ class JournalManager(private val context: Context) {
             Toast.makeText(context, "data not the same", Toast.LENGTH_SHORT).show()
         }
     }
+    fun getEntryAt(pos : Int) : Entry? {
+        if (journalExist()) {
+            val data: JSONArray = loadData()
+            if(pos >= 0 && data.length() > pos){
+                val value : JSONObject = data.getJSONObject(pos)
+                return createEntryFromJSONObject(value)
+            }
+        }
+        return null
+    }
+    private fun createEntryFromJSONObject(jsonObject : JSONObject) : Entry {
+        val title = jsonObject.getString("title")
+        val text = jsonObject.getString("text")
+        val color = jsonObject.getString("color")
+        val dateCreatedString = jsonObject.getString("dateCreated")
+        val dateFormat = SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy")
+        val dateCreated = dateFormat.parse(dateCreatedString)
+        return Entry(
+                title = title,
+                text = text,
+                color = color,
+                dateCreated = dateCreated
+            )
+    }
 }


### PR DESCRIPTION
Message triggers added for:
-entry creation
-entry update
-entry deletion
Added permissions requests for exact timer scheduling
Timed messages now take into account user's chosen minimum send delay